### PR TITLE
[Fix] Move to curl and shows errors on fetch of script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,20 @@ To install the program, download the installer and execute it.
 
 ```zsh
 cd ~
-wget https://raw.githubusercontent.com/Angelmmiguel/pm/master/install.sh
-chmod 755 ./install.sh
+curl https://raw.githubusercontent.com/Angelmmiguel/pm/master/install.sh -o pm-install.sh
+chmod 755 ./pm-install.sh
 ```
 
 If you want to install last stable version, only run downloaded script:
 
 ```zsh
-. ./install.sh
+. ./pm-install.sh
 ```
 
 If you want to install latest development version, run the installer with `--prerelease` option:
 
 ```zsh
-./install.sh --prerelease
+./pm-install.sh --prerelease
 ```
 
 Type your shell when the installer ask to you:

--- a/install.sh
+++ b/install.sh
@@ -61,10 +61,10 @@ case "$console" in
       mkdir $PM_BASE
     fi
 
-    $(wget --quiet https://raw.githubusercontent.com/Angelmmiguel/pm/${VERSION}/zsh/pm.zsh -o /tmp/pm.zsh)
+    $(curl https://raw.githubusercontent.com/Angelmmiguel/pm/${VERSION}/zsh/pm.zsh -o /tmp/pm.zsh)
     mv /tmp/pm.zsh $PM_BASE
 
-    $(wget --quiet https://raw.githubusercontent.com/Angelmmiguel/pm/${VERSION}/zsh/_pm -o /tmp/_pm)
+    $(curl https://raw.githubusercontent.com/Angelmmiguel/pm/${VERSION}/zsh/_pm -o /tmp/_pm)
     mv /tmp/_pm $ZSH_CUSTOM/plugins/pm/_pm
 
     # Add the function to the console
@@ -97,7 +97,7 @@ case "$console" in
     if [ "$FROM_UPDATE" = "no" ]; then
       mkdir $PM_BASE
     fi
-    $(wget --quiet https://raw.githubusercontent.com/Angelmmiguel/pm/${VERSION}/bash/pm.bash -o /tmp/pm.bash)
+    $(curl https://raw.githubusercontent.com/Angelmmiguel/pm/${VERSION}/bash/pm.bash -o /tmp/pm.bash)
     mv /tmp/pm.bash $PM_BASE
 
     # Add the function to the console


### PR DESCRIPTION
I'm proposing removing the use of wget for two reasons:

 - Using wget was set to `--quiet` which hides an error message around
using the `--no-check-certificate` but users can't see that. cURL works
and doesn't need to have any extra flags passed to the command.

 - wget is not installed as standard on macs where cURL is, alternatively
I'm happy for this to be declined and add an error on it being missing as
a pre-install check? This is possibly causing issues for others installing
on the latest versions of macOS too.